### PR TITLE
Refactor WeekCalendar to controlled component and fix circular updates

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -281,7 +281,7 @@ export default function DashboardPage() {
     }
   }, [scheduleStatus])
 
-  const onWeekCalendarUpdate = useCallback((blocks: Record<string, WeekCalendarTimeBlock[]>) => {
+  const onBlocksChange = useCallback((blocks: Record<string, WeekCalendarTimeBlock[]>) => {
     setWeekBlocks(blocks)
     const unassigned = Object.values(blocks).some((dayBlocks) => 
       dayBlocks.some((block) => !block.activityId)
@@ -437,8 +437,8 @@ export default function DashboardPage() {
           <WeekCalendar
             weekStart={currentWeek}
             isReadOnly={!isEditable || isSaving} // Also make read-only if saving
-            initialBlocks={weekBlocks}
-            onUpdate={onWeekCalendarUpdate}
+            blocks={weekBlocks}
+            onBlocksChange={onBlocksChange}
           />
 
           {copySuccess && (


### PR DESCRIPTION
This commit addresses a "Maximum update depth exceeded" error caused by circular state synchronization between WeekCalendar (child) and its parent.

Key changes:

1.  **Removed Problematic useEffect**: Deleted the useEffect in WeekCalendar that was syncing `initialBlocks` to internal `dayBlocks` state, a primary cause of the infinite loop.

2.  **Controlled Component Pattern**: Refactored `WeekCalendar` to be a fully controlled component:
    *   Removed its internal `dayBlocks` state.
    *   It now receives `blocks` directly as a prop from the parent.
    *   All changes to blocks are propagated to the parent via an
        `onBlocksChange` callback.
    *   The parent component (`dashboard/page.tsx`) now manages the
        `weekBlocks` state entirely.

3.  **State Initialization & Interaction Handling (Interim Steps)**:
    *   Added `currentWeekStart` state and `isUserInteractionRef` ref
        as part of an incremental approach before fully moving to the
        controlled pattern. These were subsequently removed or made
        obsolete by the full controlled component refactor.

4.  **Parent Component Update**: Updated `dashboard/page.tsx` to pass `blocks` and `onBlocksChange` props to `WeekCalendar` and renamed the handler accordingly.

5.  **Debugging**: Added a render counter in `WeekCalendar` to detect and warn about potential excessive re-renders in the future.

This new architecture establishes a clear unidirectional data flow, eliminating the circular dependencies and resolving the infinite loop issue.